### PR TITLE
Separate features: sort_pyobject vs. sort_json

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -231,4 +231,4 @@ a = [{
       "title": "BLM Idaho ACEC Historical Poly Hub"
     }]
 
-sansjson.sort(a)
+sansjson.sort_pyobject(a)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sansjson"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
   { name="nickumia", email="nickumia6@gmail.com" },
 ]

--- a/sansjson/README.md
+++ b/sansjson/README.md
@@ -44,9 +44,9 @@ pip install sansjson
 ```python
 >>> import sansjson
 >>> to_sort = {'a': 0, 'g': [3, 1, 3, 2], 'c': 1, 'f': 2}
->>> sansjson.sort(to_sort)
+>>> sansjson.sort_pyobject(to_sort)
 {'a': 0, 'c': 1, 'f': 2, 'g': [1, 2, 3, 3]}
->>> a = {'z': 1, 'a': { '12': True, 'ef': ['a', 1, False], 'ap': 0}}
->>> sansjson.sort(a)
-{'a': {'12': True, 'ap': 0, 'ef': [False, 1, 'a']}, 'z': 1}
+>>> a = '{"z": 1, "a": {"12": true, "ef": ["a", 1, false], "ap": 0}}'
+>>> sansjson.sort_json(a)
+'{"a": {"12": true, "ap": 0, "ef": [false, 1, "a"]}, "z": 1}'
 ```

--- a/sansjson/__init__.py
+++ b/sansjson/__init__.py
@@ -2,8 +2,16 @@
 from . import utils
 
 
-def sort(sans):
+def sort_pyobject(sans):
     processor = utils.Sorter()
+    if not processor.is_sortable(sans):
+        raise SystemError('Input is not sortable.')
+
+    return processor.sort()
+
+
+def sort_json(sans):
+    processor = utils.JSONSorter()
     if not processor.is_sortable(sans):
         raise SystemError('Input is not sortable.')
 

--- a/sansjson/__init__.py
+++ b/sansjson/__init__.py
@@ -11,8 +11,8 @@ def sort_pyobject(sans):
 
 
 def sort_json(sans):
-    processor = utils.JSONSorter()
-    if not processor.is_sortable(sans):
+    processor = utils.Sorter()
+    if not processor.is_json_sortable(sans):
         raise SystemError('Input is not sortable.')
 
-    return processor.sort()
+    return utils._convert_to_json(processor.sort())

--- a/sansjson/tests/conftest.py
+++ b/sansjson/tests/conftest.py
@@ -1,7 +1,7 @@
 
 import pytest
 import sansjson
-from sansjson.utils import Hasher, Sorter, JSONSorter
+from sansjson.utils import Hasher, Sorter
 
 
 @pytest.fixture(scope='function')
@@ -29,8 +29,7 @@ def compare(a, b, t):
 @pytest.fixture(scope='function')
 def sortable_test(a, p, j):
     m = Sorter()
-    n = JSONSorter()
 
     assert m.is_sortable(a) is p
-    assert n.is_sortable(a) is j
+    assert m.is_json_sortable(a) is j
     return True

--- a/sansjson/tests/conftest.py
+++ b/sansjson/tests/conftest.py
@@ -27,16 +27,10 @@ def compare(a, b, function='pyobject'):
 
 
 @pytest.fixture(scope='function')
-def json_sortable_test(a, b):
+def sortable_test(a, py_sortable, json_sortable):
+    q = Sorter()
     p = JSONSorter()
 
-    assert p.is_sortable(a) is b
-    return True
-
-
-@pytest.fixture(scope='function')
-def pyobject_sortable_test(a, b):
-    p = Sorter()
-
-    assert p.is_sortable(a) is b
+    assert p.is_sortable(a) is json_sortable
+    assert q.is_sortable(a) is py_sortable
     return True

--- a/sansjson/tests/conftest.py
+++ b/sansjson/tests/conftest.py
@@ -6,9 +6,6 @@ from sansjson.utils import Hasher, Sorter
 
 @pytest.fixture(scope='function')
 def compare(a, b, t):
-    bad = Hasher()
-    bad.data = a
-
     if t == 'json':
         c = sansjson.sort_json(a)
     else:
@@ -20,7 +17,6 @@ def compare(a, b, t):
     good = Hasher()
     good.data = c
 
-    assert hash(bad) != hash(good)
     assert hash(good) == hash(reference)
 
     return True

--- a/sansjson/tests/conftest.py
+++ b/sansjson/tests/conftest.py
@@ -27,10 +27,10 @@ def compare(a, b, function='pyobject'):
 
 
 @pytest.fixture(scope='function')
-def sortable_test(a, py_sortable, json_sortable):
-    q = Sorter()
-    p = JSONSorter()
+def sortable_test(a, p, j):
+    m = Sorter()
+    n = JSONSorter()
 
-    assert p.is_sortable(a) is json_sortable
-    assert q.is_sortable(a) is py_sortable
+    assert m.is_sortable(a) is p
+    assert n.is_sortable(a) is j
     return True

--- a/sansjson/tests/conftest.py
+++ b/sansjson/tests/conftest.py
@@ -5,11 +5,11 @@ from sansjson.utils import Hasher, Sorter, JSONSorter
 
 
 @pytest.fixture(scope='function')
-def compare(a, b, function='pyobject'):
+def compare(a, b, t):
     bad = Hasher()
     bad.data = a
 
-    if function == 'json':
+    if t == 'json':
         c = sansjson.sort_json(a)
     else:
         c = sansjson.sort_pyobject(a)

--- a/sansjson/tests/conftest.py
+++ b/sansjson/tests/conftest.py
@@ -1,15 +1,18 @@
 
 import pytest
 import sansjson
-from sansjson.utils import Hasher, Sorter
+from sansjson.utils import Hasher, Sorter, JSONSorter
 
 
 @pytest.fixture(scope='function')
-def compare(a, b):
+def compare(a, b, function='pyobject'):
     bad = Hasher()
     bad.data = a
 
-    c = sansjson.sort(a)
+    if function == 'json':
+        c = sansjson.sort_json(a)
+    else:
+        c = sansjson.sort_pyobject(a)
 
     reference = Hasher()
     reference.data = b
@@ -24,7 +27,15 @@ def compare(a, b):
 
 
 @pytest.fixture(scope='function')
-def sortable_test(a, b):
+def json_sortable_test(a, b):
+    p = JSONSorter()
+
+    assert p.is_sortable(a) is b
+    return True
+
+
+@pytest.fixture(scope='function')
+def pyobject_sortable_test(a, b):
     p = Sorter()
 
     assert p.is_sortable(a) is b

--- a/sansjson/tests/test_sort_dict.py
+++ b/sansjson/tests/test_sort_dict.py
@@ -3,12 +3,12 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    'a, b',
+    'a, b, t',
     [
         # One-level
         (
             {'z': 1, 'a': 2, 'y': 3, 'c': 4},
-            {'a': 2, 'c': 4, 'y': 3, 'z': 1}
+            {'a': 2, 'c': 4, 'y': 3, 'z': 1}, 'pyobject'
         ),
         # Two-levels
         (
@@ -31,7 +31,7 @@ import pytest
                  'ue': 'def',
                  'yh': 'abc'},
              'y': 3,
-             'z': 1}
+             'z': 1}, 'pyobject'
         ),
         # Three-levels
         (
@@ -66,7 +66,7 @@ import pytest
                  'ue': 'def',
                  'yh': 'abc'},
              'y': 3,
-             'z': 1}
+             'z': 1}, 'pyobject'
         ),
         # Two-levels with list as leaf
         (
@@ -79,9 +79,9 @@ import pytest
                 '12': True,
                 'ap': 0,
                 'ef': [False, 1, 'a']},
-             'z': 1}
+             'z': 1}, 'pyobject'
         ),
     ]
 )
-def test_sorted(a, b, compare):
+def test_sorted(a, b, t, compare):
     assert compare

--- a/sansjson/tests/test_sort_json.py
+++ b/sansjson/tests/test_sort_json.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    'a, b, c',
+    'a, b, function',
     [
         # Two-levels with list as leaf
         (
@@ -20,5 +20,5 @@ import pytest
         ),
     ]
 )
-def test_sorted(a, b, c, compare):
+def test_sorted(a, b, function, compare):
     assert compare

--- a/sansjson/tests/test_sort_json.py
+++ b/sansjson/tests/test_sort_json.py
@@ -8,7 +8,7 @@ import pytest
         # Two-levels with list as leaf
         (
             '{"z": 1, "a": {"12": true, "ef": ["a", 1, false], "ap": 0}}',
-            '{"a": {"12": true, "ef": ["a", 1, false], "ap": 0}, "z": 1}',
+            '{"a": {"12": true, "ap": 0, "ef": [false, 1, "a"]}, "z": 1}',
             "json"
         ),
     ]

--- a/sansjson/tests/test_sort_json.py
+++ b/sansjson/tests/test_sort_json.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    'a, b, function',
+    'a, b, t',
     [
         # Two-levels with list as leaf
         (
@@ -20,5 +20,5 @@ import pytest
         ),
     ]
 )
-def test_sorted(a, b, function, compare):
+def test_sorted(a, b, t, compare):
     assert compare

--- a/sansjson/tests/test_sort_json.py
+++ b/sansjson/tests/test_sort_json.py
@@ -8,7 +8,7 @@ import pytest
         # Two-levels with list as leaf
         (
             '{"z": 1, "a": {"12": true, "ef": ["a", 1, false], "ap": 0}}',
-            '{"a": {"12": true, "ef": ["a", 1, false], "ap": 0}, "z": 1}'
+            '{"a": {"12": true, "ef": ["a", 1, false], "ap": 0}, "z": 1}',
             "json"
         ),
     ]

--- a/sansjson/tests/test_sort_json.py
+++ b/sansjson/tests/test_sort_json.py
@@ -1,0 +1,24 @@
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    'a, b, c',
+    [
+        # Two-levels with list as leaf
+        (
+            """{'z': 1,
+             'a': {
+                 '12': True,
+                 'ef': ['a', 1, False],
+                 'ap': 0}}""",
+            """{'a': {
+                '12': True,
+                'ap': 0,
+                'ef': [False, 1, 'a']},
+             'z': 1}""", "json"
+        ),
+    ]
+)
+def test_sorted(a, b, c, compare):
+    assert compare

--- a/sansjson/tests/test_sort_json.py
+++ b/sansjson/tests/test_sort_json.py
@@ -7,16 +7,9 @@ import pytest
     [
         # Two-levels with list as leaf
         (
-            """{'z': 1,
-             'a': {
-                 '12': True,
-                 'ef': ['a', 1, False],
-                 'ap': 0}}""",
-            """{'a': {
-                '12': True,
-                'ap': 0,
-                'ef': [False, 1, 'a']},
-             'z': 1}""", "json"
+            '{"z": 1, "a": {"12": true, "ef": ["a", 1, false], "ap": 0}}',
+            '{"a": {"12": true, "ef": ["a", 1, false], "ap": 0}, "z": 1}'
+            "json"
         ),
     ]
 )

--- a/sansjson/tests/test_sort_json.py
+++ b/sansjson/tests/test_sort_json.py
@@ -5,6 +5,10 @@ import pytest
 @pytest.mark.parametrize(
     'a, b, t',
     [
+        # Super Basic
+        (
+            '{"a": "1"}', '{"a": "1"}', "json"
+        ),
         # Two-levels with list as leaf
         (
             '{"z": 1, "a": {"12": true, "ef": ["a", 1, false], "ap": 0}}',

--- a/sansjson/tests/test_sort_list.py
+++ b/sansjson/tests/test_sort_list.py
@@ -7,39 +7,39 @@ o = Hasher()
 
 # TODO: fix objects
 @pytest.mark.parametrize(
-    'a, b',
+    'a, b, t',
     [
         # Homogenous
         (
             [3, 5, 4, 2],
-            [2, 3, 4, 5]
+            [2, 3, 4, 5], 'pyobject'
         ),
         # Non-Homogenous
         (
             [None, 'a', 2, None],
-            [None, None, 2, 'a']
+            [None, None, 2, 'a'], 'pyobject'
         ),
         # Non-Homogenous Array 2
         (
             ['z', 1, 'a', 2, 'y', 3, 'c', 4],
-            [1, 2, 3, 4, 'a', 'c', 'y', 'z']
+            [1, 2, 3, 4, 'a', 'c', 'y', 'z'], 'pyobject'
         ),
         # Non-Homogenous 3
         (
             [None, 'z', 2, None, True, False, 1, 'a'],
-            [None, None, False, True, 1, 2, 'a', 'z']
+            [None, None, False, True, 1, 2, 'a', 'z'], 'pyobject'
         ),
         # Array of 'objects'
         (
             [{'z': 1, 'a': 2}, {'y': 3, 'c': 4}],
-            [{'a': 2, 'z': 1}, {'c': 4, 'y': 3}]
+            [{'a': 2, 'z': 1}, {'c': 4, 'y': 3}], 'pyobject'
         ),
         # Array of 'objects' + other stuff
         (
             [{'z': 10, 'a': 2},
              {'y': 3, 'c': 4}, 'a', 1, {'z': 1, 'a': 2}, True],
             [True, 1, 'a',
-             {'a': 2, 'z': 1}, {'a': 2, 'z': 10}, {'c': 4, 'y': 3}]
+             {'a': 2, 'z': 1}, {'a': 2, 'z': 10}, {'c': 4, 'y': 3}], 'pyobject'
         ),
         # Array of 'objects' + other stuff 2
         (
@@ -48,22 +48,22 @@ o = Hasher()
              {'a': [{'x': 9}, {'s': 8}]}, True],
             [True, 1, 'a', {'a': 2, 'y': 3, 'z': 10},
              {'a': [{'r': 0}, {'y': 0}, {'y': 3}]},
-             {'a': [{'s': 8}, {'x': 9}]}]
+             {'a': [{'s': 8}, {'x': 9}]}], 'pyobject'
         ),
         # Array of dicts -- first dict longer
         (
             [{'a': 1, 'c': 3, 'b': 2}, {'b': 2, 'a': 1}],
-            [{'a': 1, 'b': 2}, {'a': 1, 'b': 2, 'c': 3}]
+            [{'a': 1, 'b': 2}, {'a': 1, 'b': 2, 'c': 3}], 'pyobject'
         ),
         # Array of dicts -- second dict longer
         (
             [{'b': 2, 'a': 1}, {'a': 1, 'c': 3, 'b': 2}],
-            [{'a': 1, 'b': 2}, {'a': 1, 'b': 2, 'c': 3}]
+            [{'a': 1, 'b': 2}, {'a': 1, 'b': 2, 'c': 3}], 'pyobject'
         ),
         # Array of dicts -- dicts are the same size
         (
             [{'b': 2, 'a': 1}, {'a': 1, 'b': 2}],
-            [{'a': 1, 'b': 2}, {'a': 1, 'b': 2}]
+            [{'a': 1, 'b': 2}, {'a': 1, 'b': 2}], 'pyobject'
         ),
         # Array of dicts -- nonhomogenous values
         # TODO: doesn't work
@@ -74,19 +74,19 @@ o = Hasher()
         # Array of dicts -- value variant 2
         (
             [{'a': [{1: 3}, {1: 1}]}, {'a': [{1: 5}, {1: 1}]}],
-            [{'a': [{1: 1}, {1: 3}]}, {'a': [{1: 1}, {1: 5}]}]
+            [{'a': [{1: 1}, {1: 3}]}, {'a': [{1: 1}, {1: 5}]}], 'pyobject'
         ),
         # Array of dicts -- value variant 3
         (
             [{'a': [{2: 3}, {1: 1}]}, {'a': [{4: 5}, {1: 1}]}],
-            [{'a': [{1: 1}, {2: 3}]}, {'a': [{1: 1}, {4: 5}]}]
+            [{'a': [{1: 1}, {2: 3}]}, {'a': [{1: 1}, {4: 5}]}], 'pyobject'
         ),
         # Array of dicts -- value variant 4 (list + non-list)
         (
             [{'a': [{1: 3}, {1: 1}]}, {'a': 1}],
-            [{'a': 1}, {'a': [{1: 1}, {1: 3}]}]
+            [{'a': 1}, {'a': [{1: 1}, {1: 3}]}], 'pyobject'
         ),
     ]
 )
-def test_sortable_homogenous(a, b, compare):
+def test_sortable_homogenous(a, b, t, compare):
     assert compare

--- a/sansjson/tests/test_sorter.py
+++ b/sansjson/tests/test_sorter.py
@@ -4,23 +4,23 @@ from sansjson.utils import Hasher
 
 
 @pytest.mark.parametrize(
-    'a, b',
+    'a, p, j',
     [
         # dict
-        ({'a': 1, 'b': 2, 'c': 3}, True),
+        ({'a': 1, 'b': 2, 'c': 3}, True, False),
         # JSON str
-        ('{"a": 1, "b": 2, "c": 3}', True),
+        ('{"a": 1, "b": 2, "c": 3}', False, True),
         # list
-        ([1, 3, 2], True),
+        ([1, 3, 2], True, False),
         # JSON str (bad)
-        ('{"a": 1, "b": 2, "c: 3}', False),
+        ('{"a": 1, "b": 2, "c: 3}', False, False),
         # int
-        (1, False),
+        (1, False, False),
         # none
-        (None, False),
+        (None, False, False),
         # object
-        (Hasher(), False)
+        (Hasher(), False, False)
     ]
 )
-def test_sortable(a, b, sortable_test):
+def test_sortable(a, p, j, sortable_test):
     assert sortable_test

--- a/sansjson/utils.py
+++ b/sansjson/utils.py
@@ -49,7 +49,6 @@ class Sorter(Hasher):
     Supported types:
         - _dict_: sort key order
         - _list_: see 'nonhomogenous'
-        - _str_: convert to _dict_
     '''
 
     def __init__(self):
@@ -59,14 +58,6 @@ class Sorter(Hasher):
         if isinstance(deck, dict):
             self.data = deck
             return True
-        if isinstance(deck, str):
-            try:
-                self.data = json.loads(deck)
-                return True
-            except json.decoder.JSONDecodeError:
-                # log.error(
-                #     'Input is str, but could not be parsed into JSON dict.')
-                return False
         if isinstance(deck, list):
             self.data = deck
             return True
@@ -102,6 +93,31 @@ class Sorter(Hasher):
             sorted_dict = self.recursive_dict(context)
 
         return sorted_dict
+
+
+class JSONSorter(Sorter):
+    '''
+    Sorter class to specifically handle JSON string input
+
+    Supported types:
+        - _str_: convert to _dict_
+    '''
+
+    def __init__(self):
+        super(JSONSorter, self).__init__()
+
+    def is_sortable(self, deck):
+        if isinstance(deck, str):
+            try:
+                self.data = json.loads(deck)
+                return True
+            except json.decoder.JSONDecodeError:
+                return False
+        return False
+
+    def sort(self, context=None):
+        data = super(JSONSorter, self).sort(context)
+        return json.dumps(data)
 
 
 def dict_sort_key(dicta, dictb):

--- a/sansjson/utils.py
+++ b/sansjson/utils.py
@@ -49,6 +49,7 @@ class Sorter(Hasher):
     Supported types:
         - _dict_: sort key order
         - _list_: see 'nonhomogenous'
+        - _str_: convert to _dict_
     '''
 
     def __init__(self):
@@ -61,6 +62,15 @@ class Sorter(Hasher):
         if isinstance(deck, list):
             self.data = deck
             return True
+        return False
+
+    def is_json_sortable(self, deck):
+        if isinstance(deck, str):
+            try:
+                self.data = json.loads(deck)
+                return True
+            except json.decoder.JSONDecodeError:
+                return False
         return False
 
     def recursive_dict(self, context):
@@ -95,29 +105,8 @@ class Sorter(Hasher):
         return sorted_dict
 
 
-class JSONSorter(Sorter):
-    '''
-    Sorter class to specifically handle JSON string input
-
-    Supported types:
-        - _str_: convert to _dict_
-    '''
-
-    def __init__(self):
-        super(JSONSorter, self).__init__()
-
-    def is_sortable(self, deck):
-        if isinstance(deck, str):
-            try:
-                self.data = json.loads(deck)
-                return True
-            except json.decoder.JSONDecodeError:
-                return False
-        return False
-
-    def sort(self, context=None):
-        data = super(JSONSorter, self).sort(context)
-        return json.dumps(data)
+def _convert_to_json(data):
+    return json.dumps(data)
 
 
 def dict_sort_key(dicta, dictb):


### PR DESCRIPTION
Changes:
Feature Request by @fuhuxia to make the input match the output.  This creates dedicated functions for each feature.
- list --> list
- dict --> dict
- json_str --> json_str
- update test infrastructure accordingly
- (BREAKING) `sort` not longer a valid function, need to use either `sort_pyobject` or `sort_json`